### PR TITLE
Add REST API fallback for network stats and improve kaspa-node detection

### DIFF
--- a/services/dashboard/public/scripts/modules/ui-manager.js
+++ b/services/dashboard/public/scripts/modules/ui-manager.js
@@ -1767,6 +1767,16 @@ export class UIManager {
     }
 
     /**
+     * Show or hide the Local Node Status panel based on whether kaspa-node is installed
+     */
+    setNodePanelVisible(visible) {
+        const nodePanel = document.querySelector('.card.node-info');
+        if (nodePanel) {
+            nodePanel.style.display = visible ? '' : 'none';
+        }
+    }
+
+    /**
      * Update enhanced network stats with all new fields
      */
     updateEnhancedNetworkStats(networkData) {


### PR DESCRIPTION
## Summary
This PR enhances the dashboard's resilience by adding a REST API fallback tier for network statistics when gRPC connections fail, and improves the handling of kaspa-node installation detection to prevent unnecessary API calls.

## Key Changes

- **Fixed API endpoint typo**: Corrected `/info/blockg/info` to `/info/blockdag` in the public Kaspa API endpoint
- **Added REST API fallback tier**: Implemented a third-tier fallback mechanism in the enhanced network stats endpoint that attempts to fetch blockdag data from public REST APIs (`api.kaspa.org` and `kas.fyi`) when both local and public gRPC nodes fail
- **Improved kaspa-node detection**: Added `kaspaNodeInstalled` flag to track whether kaspa-node service is installed, preventing unnecessary sync status and node-specific API calls when the service isn't available
- **Conditional node panel visibility**: Added `setNodePanelVisible()` method to show/hide the Local Node Status panel based on kaspa-node installation status
- **Optimized data loading**: Modified `loadKaspaInfo()` to skip local node status calls if kaspa-node isn't installed, while still loading public network statistics

## Implementation Details

- The REST API fallback attempts multiple endpoints sequentially and validates responses contain expected fields (`virtualDaaScore` or `blockCount`)
- Network stats calculation (hash rate, block reward, circulating supply) works with REST API data just as it does with gRPC data
- Service refresh logic now checks kaspa-node installation status in two locations to ensure consistent UI state
- Error handling maintains detailed logging for debugging while providing user-friendly error messages

https://claude.ai/code/session_0138TRAVCLx37CrGyCrHNHcW